### PR TITLE
Use absolute csproj paths

### DIFF
--- a/src/ATech.Ring.DotNet.Cli/Runnables/Dotnet/DotnetContext.cs
+++ b/src/ATech.Ring.DotNet.Cli/Runnables/Dotnet/DotnetContext.cs
@@ -36,7 +36,7 @@ public class DotnetContext : ICsProjContext, ITrackRetries, ITrackProcessId, ITr
                 config.CsProj = Path.Combine(resolveFullClonePath(fromGit), config.CsProj);
             }
 
-            ctx.CsProjPath = config.CsProj;
+            ctx.CsProjPath = config.FullPath;
             (ctx.TargetFramework, ctx.TargetRuntime) = config.GetTargetFrameworkAndRuntime();
             ctx.WorkingDir = config.GetWorkingDir();
             var runtimePathSegment = ctx.TargetRuntime == null ? "" : $"{Path.DirectorySeparatorChar}{ctx.TargetRuntime}";

--- a/src/ATech.Ring.DotNet.Cli/packages.lock.json
+++ b/src/ATech.Ring.DotNet.Cli/packages.lock.json
@@ -80,8 +80,8 @@
       "Serilog.AspNetCore": {
         "type": "Direct",
         "requested": "[6.*, )",
-        "resolved": "6.0.1",
-        "contentHash": "5XW90k62V7G9I0D/j9Iz+NyRBB6/SnoFpHUPeLnV40gONV2vs2A/ewWi91QVjQmyHBfzFeqIrkvE/DJMZ0alTg==",
+        "resolved": "6.1.0",
+        "contentHash": "iMwFUJDN+/yWIPz4TKCliagJ1Yn//SceCYCzgdPwe/ECYUwb5/WUL8cTzRKV+tFwxGjLEV/xpm0GupS5RwbhSQ==",
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection": "5.0.0",
           "Microsoft.Extensions.Logging": "5.0.0",
@@ -94,11 +94,11 @@
           "Serilog.Sinks.File": "5.0.0"
         }
       },
-      "stateless": {
+      "Stateless": {
         "type": "Direct",
         "requested": "[5.*, )",
-        "resolved": "5.11.0",
-        "contentHash": "5XXmdEQBOpgE90vqxfZH0ekdqfGB6xLe0Uyb7EyHr/fgv/zkZtDcru4KxRvAvWxE1u4c8MOZnOnXoRfQOfFnTg=="
+        "resolved": "5.13.0",
+        "contentHash": "M4Rb4b31TUEfhCd4en0WlRfuFgQ2rwva9e1CuXnto5vNGvRsNVimHENnvjegf6nKG9ZH+51McAZ/huqRtTziYg=="
       },
       "Tomlyn.Extensions.Configuration": {
         "type": "Direct",
@@ -768,8 +768,8 @@
       },
       "System.Text.Json": {
         "type": "Transitive",
-        "resolved": "6.0.5",
-        "contentHash": "SSH+YYrMpvLcy7Orzb5K1tSyffnFacWahyxCCjYH1PbSHdAF4dekmIetBurFKgtTHDmwEe/J2Csi/7niRH6d/g==",
+        "resolved": "6.0.7",
+        "contentHash": "/Tf/9XjprpHolbcDOrxsKVYy/mUG/FS7aGd9YUgBVEiHeQH4kAE0T1sMbde7q6B5xcrNUsJ5iW7D1RvHudQNqA==",
         "dependencies": {
           "System.Runtime.CompilerServices.Unsafe": "6.0.0",
           "System.Text.Encodings.Web": "6.0.0"


### PR DESCRIPTION
Repro: when using nested `ring.toml` structure like:

``` toml
###`./ring.toml

imports = [
  "src/some/ring.toml"
]
### ------------------
### ./src/some/ring.toml

[[aspnetcore]]
csproj = "else/else.csproj"

```

The `csproj` path does not take into account the nested nature of the files above. We do already calculate the correct full path for the project so we can use that instead. 
