### PR TITLE
fix: try dotnet build 3 times

### DIFF
--- a/src/ATech.Ring.DotNet.Cli/Runnables/Dotnet/DotnetRunnable.cs
+++ b/src/ATech.Ring.DotNet.Cli/Runnables/Dotnet/DotnetRunnable.cs
@@ -1,3 +1,4 @@
+using System;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
@@ -39,7 +40,8 @@ public abstract class DotnetRunnableBase<TContext, TConfig> : ProcessRunnable<TC
         if (File.Exists(ctx.EntryAssemblyPath)) return ctx;
 
         _logger.LogDebug("Building {Project}", ctx.CsProjPath);
-        var result = await Dotnet.BuildAsync(ctx.CsProjPath, token);
+        var result =
+            await Dotnet.TryAsync(3, TimeSpan.FromSeconds(10), f => f.BuildAsync(ctx.CsProjPath, token), token);
 
         if (!result.IsSuccess)
         {

--- a/src/ATech.Ring.DotNet.Cli/Tools/ToolExtensions.cs
+++ b/src/ATech.Ring.DotNet.Cli/Tools/ToolExtensions.cs
@@ -38,8 +38,8 @@ public static class ToolExtensions
         return result;
     }
 
-    public static async Task<ExecutionInfo> TryAsync(this ITool t, int times, TimeSpan backOffInterval,
-        Func<ITool, Task<ExecutionInfo>> func, CancellationToken token)
+    public static async Task<ExecutionInfo> TryAsync<T>(this T t, int times, TimeSpan backOffInterval,
+        Func<T, Task<ExecutionInfo>> func, CancellationToken token) where T : ITool
         => await TryAsync(times, backOffInterval, () => func(t), r => r.IsSuccess, token);
 
     public static Task<ExecutionInfo> RunProcessWaitAsync(this ITool tool, CancellationToken token)


### PR DESCRIPTION
Running parallel independent builds of projects having common dependent projects it may cause file Access Denied errors. A simple retry should be a good temporary solution.