### PR TITLE
Enable setting project configuration

### DIFF
--- a/src/ATech.Ring.DotNet.Cli/Runnables/Dotnet/DotnetContext.cs
+++ b/src/ATech.Ring.DotNet.Cli/Runnables/Dotnet/DotnetContext.cs
@@ -26,7 +26,7 @@ public class DotnetContext : ICsProjContext, ITrackRetries, ITrackProcessId, ITr
         {
             var ctx = (T)FormatterServices.GetUninitializedObject(typeof(T));
 
-            if (config is IFromGit { SshRepoUrl: string _ } fromGit)
+            if (config is IFromGit { SshRepoUrl: not null } fromGit)
             {
                 if (Path.IsPathRooted(config.CsProj))
                 {
@@ -40,7 +40,7 @@ public class DotnetContext : ICsProjContext, ITrackRetries, ITrackProcessId, ITr
             (ctx.TargetFramework, ctx.TargetRuntime) = config.GetTargetFrameworkAndRuntime();
             ctx.WorkingDir = config.GetWorkingDir();
             var runtimePathSegment = ctx.TargetRuntime == null ? "" : $"{Path.DirectorySeparatorChar}{ctx.TargetRuntime}";
-            ctx.EntryAssemblyPath = Path.Combine(ctx.WorkingDir, $"bin{Path.DirectorySeparatorChar}Debug{Path.DirectorySeparatorChar}{ctx.TargetFramework}{runtimePathSegment}{Path.DirectorySeparatorChar}{config.GetProjName()}.dll");
+            ctx.EntryAssemblyPath = Path.Combine(ctx.WorkingDir, $"bin{Path.DirectorySeparatorChar}{config.Configuration}{Path.DirectorySeparatorChar}{ctx.TargetFramework}{runtimePathSegment}{Path.DirectorySeparatorChar}{config.GetProjName()}.dll");
             return ctx;
         }
         finally

--- a/src/Queil.Ring.Configuration/Interfaces/IUseCsProjFile.cs
+++ b/src/Queil.Ring.Configuration/Interfaces/IUseCsProjFile.cs
@@ -5,4 +5,5 @@ public interface IUseCsProjFile : IUseWorkingDir
     string CsProj { get; set; }
     string FullPath { get; }
     string LaunchSettingsJsonPath { get; }
+    string Configuration { get; }
 }

--- a/src/Queil.Ring.Configuration/Runnables/CsProjRunnable.cs
+++ b/src/Queil.Ring.Configuration/Runnables/CsProjRunnable.cs
@@ -8,6 +8,7 @@ public abstract class CsProjRunnable : RunnableConfigBase, IUseCsProjFile, IFrom
     public string? WorkingDir { get; set; }
     public string CsProj { get; set; }
     public string SshRepoUrl { get; set; }
+    public string Configuration { get; set; } = "Debug";
     public string FullPath => GetFullPath(WorkingDir, CsProj);
     public string LaunchSettingsJsonPath => Path.Combine(Path.GetDirectoryName(FullPath), "Properties/launchSettings.json");
     private string _id;


### PR DESCRIPTION
This PR enables setting Configuration (as in Debug/Release) for dotnet runnables:

```toml
[[aspnetcore]]
csproj = "my.csproj"
configuration = "Release"
```
