### PR TITLE
fix: do not start runnable it a task fails

### DIFF
--- a/src/Queil.Ring.Configuration/ConfigSet.cs
+++ b/src/Queil.Ring.Configuration/ConfigSet.cs
@@ -17,7 +17,7 @@ public class ConfigSet : Dictionary<string, IRunnableConfig>
         }
 
         Path = path;
-        Flavours = [..bareConfigs.Values.SelectMany(x => x.Tags)];
+        Flavours = [.. bareConfigs.Values.SelectMany(x => x.Tags)];
     }
 
     public HashSet<string> Flavours { get; }

--- a/src/Queil.Ring.DotNet.Cli/Abstractions/DetailsExtractors.cs
+++ b/src/Queil.Ring.DotNet.Cli/Abstractions/DetailsExtractors.cs
@@ -14,7 +14,7 @@ public static class DetailsExtractors
         var details = cfg switch
         {
             CsProjRunnable c => New((DetailsKeys.CsProjPath, c.FullPath)),
-            _ => new Dictionary<string, object>()
+            _ => []
         };
 
         if (cfg.FriendlyName != null) details.Add(DetailsKeys.FriendlyName, cfg.FriendlyName);

--- a/src/Queil.Ring.DotNet.Cli/Abstractions/IRunnable.cs
+++ b/src/Queil.Ring.DotNet.Cli/Abstractions/IRunnable.cs
@@ -10,6 +10,7 @@ public interface IRunnable
     string UniqueId { get; }
     State State { get; }
     IReadOnlyDictionary<string, object> Details { get; }
+    Task ConfigureAsync(CancellationToken token);
     Task RunAsync(CancellationToken token);
     Task TerminateAsync();
     event EventHandler OnHealthCheckCompleted;

--- a/src/Queil.Ring.DotNet.Cli/Infrastructure/RingConfiguration.cs
+++ b/src/Queil.Ring.DotNet.Cli/Infrastructure/RingConfiguration.cs
@@ -75,7 +75,7 @@ public class KubernetesSettings
 public class InitHookConfig
 {
     public string? Command { get; set; }
-    public string[] Args { get; set; } = Array.Empty<string>();
+    public string[] Args { get; set; } = [];
 }
 
 public class HooksConfiguration

--- a/src/Queil.Ring.DotNet.Cli/Infrastructure/WebApplicationExtensions.cs
+++ b/src/Queil.Ring.DotNet.Cli/Infrastructure/WebApplicationExtensions.cs
@@ -19,11 +19,11 @@ public static class WebApplicationExtensions
                 await app.Services.GetRequiredService<ICloneMaker>().CloneWorkspaceRepos(c.WorkspacePath, c.OutputDir);
                 break;
             case ConfigDump:
-            {
-                var debugView = ((IConfigurationRoot)app.Services.GetRequiredService<IConfiguration>()).GetDebugView();
-                Console.WriteLine(debugView);
-                break;
-            }
+                {
+                    var debugView = ((IConfigurationRoot)app.Services.GetRequiredService<IConfiguration>()).GetDebugView();
+                    Console.WriteLine(debugView);
+                    break;
+                }
             case HeadlessOptions:
             case ConsoleOptions:
                 await app.RunAsync();

--- a/src/Queil.Ring.DotNet.Cli/Logging/ScopeLoggingExtensions.cs
+++ b/src/Queil.Ring.DotNet.Cli/Logging/ScopeLoggingExtensions.cs
@@ -28,14 +28,14 @@ public static class ScopeLoggingExtensions
     }
 
     public static IDisposable? WithClientScope<T>(this ILogger<T> logger) => logger.BeginScope(new Scope
-        { [Scope.UniqueIdKey] = "PROTOCOL", [Scope.LogEventKey] = "CLIENT" });
+    { [Scope.UniqueIdKey] = "PROTOCOL", [Scope.LogEventKey] = "CLIENT" });
 
     public static IDisposable? WithReceivedScope<T>(this ILogger<T> logger, M protocolEvent) =>
         logger.BeginScope(new Scope { [Scope.UniqueIdKey] = protocolEvent, [Scope.LogEventKey] = "<<" });
 
     public static IDisposable? WithSentScope<T>(this ILogger<T> logger, bool isDelivered, M protocolEvent) =>
         logger.BeginScope(new Scope
-            { [Scope.UniqueIdKey] = protocolEvent, [Scope.LogEventKey] = isDelivered ? ">>" : "->" });
+        { [Scope.UniqueIdKey] = protocolEvent, [Scope.LogEventKey] = isDelivered ? ">>" : "->" });
 
     public static IDisposable? WithHostScope<T>(this ILogger<T> logger, LogEvent logEvent) =>
         logger.WithScope("HOST", logEvent);
@@ -45,13 +45,13 @@ public static class ScopeLoggingExtensions
 
     public static IDisposable? WithTaskScope<T>(this ILogger<T> logger, string runtimeId, string taskId) =>
         logger.BeginScope(new Scope
-            { [Scope.UniqueIdKey] = $"{runtimeId}:{taskId}", [Scope.LogEventKey] = "TASK" });
+        { [Scope.UniqueIdKey] = $"{runtimeId}:{taskId}", [Scope.LogEventKey] = "TASK" });
 
     public static IDisposable? WithLogErrorScope<T>(this ILogger<T> logger) =>
         logger.BeginScope(new Scope
-            { [Scope.LogEventKey] = $"{Red}ERROR" });
+        { [Scope.LogEventKey] = $"{Red}ERROR" });
 
     public static IDisposable? WithLogInfoScope<T>(this ILogger<T> logger) =>
         logger.BeginScope(new Scope
-            { [Scope.LogEventKey] = $"{Gray}LOG" });
+        { [Scope.LogEventKey] = $"{Gray}LOG" });
 }

--- a/src/Queil.Ring.DotNet.Cli/Program.cs
+++ b/src/Queil.Ring.DotNet.Cli/Program.cs
@@ -112,9 +112,9 @@ try
             .Where(t => typeof(IRunnable).IsAssignableFrom(t)).ToList();
 
         var configMap = (from r in runnableTypes
-                let cfg = r.GetProperty(nameof(Runnable<object, IRunnableConfig>.Config))
-                where cfg != null
-                select (RunnableType: r, ConfigType: cfg.PropertyType))
+                         let cfg = r.GetProperty(nameof(Runnable<object, IRunnableConfig>.Config))
+                         where cfg != null
+                         select (RunnableType: r, ConfigType: cfg.PropertyType))
             .ToDictionary(x => x.ConfigType, x => x.RunnableType);
 
         foreach (var (_, rt) in configMap) container.Register(rt, rt, new PerRequestLifeTime());

--- a/src/Queil.Ring.DotNet.Cli/Runnables/Dotnet/DotnetContext.cs
+++ b/src/Queil.Ring.DotNet.Cli/Runnables/Dotnet/DotnetContext.cs
@@ -11,7 +11,7 @@ using CsProj;
 public class DotnetContext : ICsProjContext, ITrackRetries, ITrackProcessId, ITrackProcessOutput
 {
     public string ExePath => Path.ChangeExtension(EntryAssemblyPath, "exe");
-    public Dictionary<string, string> Env { get; set; } = new();
+    public Dictionary<string, string> Env { get; set; } = [];
     public string CsProjPath { get; set; }
     public string WorkingDir { get; set; }
     public string TargetFramework { get; set; }

--- a/src/Queil.Ring.DotNet.Cli/Runnables/Kustomize/KustomizeContext.cs
+++ b/src/Queil.Ring.DotNet.Cli/Runnables/Kustomize/KustomizeContext.cs
@@ -1,13 +1,12 @@
 ﻿namespace Queil.Ring.DotNet.Cli.Runnables.Kustomize;
 
-using System;
 using Abstractions.Context;
 
 public class KustomizeContext : ITrackRetries
 {
     public string KustomizationDir { get; set; }
     public string CachePath { get; set; }
-    public Namespace[] Namespaces { get; set; } = Array.Empty<Namespace>();
+    public Namespace[] Namespaces { get; set; } = [];
     public int ConsecutiveFailures { get; set; }
     public int TotalFailures { get; set; }
 }
@@ -15,5 +14,5 @@ public class KustomizeContext : ITrackRetries
 public class Namespace
 {
     public string Name { get; set; }
-    public string[] Pods { get; set; } = Array.Empty<string>();
+    public string[] Pods { get; set; } = [];
 }

--- a/src/Queil.Ring.DotNet.Cli/Runnables/Kustomize/KustomizeRunnable.cs
+++ b/src/Queil.Ring.DotNet.Cli/Runnables/Kustomize/KustomizeRunnable.cs
@@ -1,4 +1,4 @@
-﻿using static Queil.Ring.DotNet.Cli.Tools.ToolExtensions;
+﻿using static Queil.Ring.DotNet.Cli.Tools.RunProcess;
 using KustomizeConfig = Queil.Ring.Configuration.Runnables.Kustomize;
 
 namespace Queil.Ring.DotNet.Cli.Runnables.Kustomize;

--- a/src/Queil.Ring.DotNet.Cli/Tools/DockerCompose.cs
+++ b/src/Queil.Ring.DotNet.Cli/Tools/DockerCompose.cs
@@ -13,18 +13,18 @@ public class DockerCompose(ILogger<ITool> logger) : ITool
     public ILogger<ITool> Logger { get; } = logger;
 
     public async Task<ExecutionInfo> RmAsync(string composeFilePath, CancellationToken token) =>
-        await this.RunAsync(["-f", $"\"{composeFilePath}\"", "rm", "-f"], wait: true, token: token);
+        await this.RunAsync(["-f", $"\"{composeFilePath}\"", "rm", "-f"], foreground: true, token: token);
 
     public async Task<ExecutionInfo> PullAsync(string composeFilePath, CancellationToken token) =>
-        await this.RunAsync(["-f", $"\"{composeFilePath}\"", "pull"], wait: true, token: token);
+        await this.RunAsync(["-f", $"\"{composeFilePath}\"", "pull"], foreground: true, token: token);
 
     public async Task<ExecutionInfo> UpAsync(string composeFilePath, CancellationToken token) =>
-        await this.RunAsync(["-f", $"\"{composeFilePath}\"", "up", "--force-recreate"], wait: true,
+        await this.RunAsync(["-f", $"\"{composeFilePath}\"", "up", "--force-recreate"], foreground: true,
             token: token);
 
     public async Task<ExecutionInfo> DownAsync(string composeFilePath, CancellationToken token) =>
-        await this.RunAsync(["-f", $"\"{composeFilePath}\"", "down"], wait: true, token: token);
+        await this.RunAsync(["-f", $"\"{composeFilePath}\"", "down"], foreground: true, token: token);
 
     public async Task<ExecutionInfo> StopAsync(string composeFilePath, CancellationToken token) =>
-        await this.RunAsync(["-f", $"\"{composeFilePath}\"", "stop"], wait: true, token: token);
+        await this.RunAsync(["-f", $"\"{composeFilePath}\"", "stop"], foreground: true, token: token);
 }

--- a/src/Queil.Ring.DotNet.Cli/Tools/DockerCompose.cs
+++ b/src/Queil.Ring.DotNet.Cli/Tools/DockerCompose.cs
@@ -1,6 +1,5 @@
 namespace Queil.Ring.DotNet.Cli.Tools;
 
-using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Abstractions.Tools;
@@ -9,7 +8,7 @@ using Microsoft.Extensions.Logging;
 public class DockerCompose(ILogger<ITool> logger) : ITool
 {
     public string Command { get; set; } = "docker-compose";
-    public string[] DefaultArgs { get; set; } = Array.Empty<string>();
+    public string[] DefaultArgs { get; set; } = [];
     public ILogger<ITool> Logger { get; } = logger;
 
     public async Task<ExecutionInfo> RmAsync(string composeFilePath, CancellationToken token) =>

--- a/src/Queil.Ring.DotNet.Cli/Tools/DotnetCliBundle.cs
+++ b/src/Queil.Ring.DotNet.Cli/Tools/DotnetCliBundle.cs
@@ -16,7 +16,7 @@ public class DotnetCliBundle(ProcessRunner processRunner, ILogger<DotnetCliBundl
     private readonly Dictionary<string, string> DefaultEnvVars = new() { ["ASPNETCORE_ENVIRONMENT"] = "Development" };
     public ILogger<ITool> Logger { get; } = logger;
     public string Command { get; set; } = "dotnet";
-    public string[] DefaultArgs { get; set; } = Array.Empty<string>();
+    public string[] DefaultArgs { get; set; } = [];
 
     public async Task<ExecutionInfo> RunAsync(DotnetContext ctx, CancellationToken token, string[]? urls = null)
     {

--- a/src/Queil.Ring.DotNet.Cli/Tools/DotnetCliBundle.cs
+++ b/src/Queil.Ring.DotNet.Cli/Tools/DotnetCliBundle.cs
@@ -47,6 +47,6 @@ public class DotnetCliBundle(ProcessRunner processRunner, ILogger<DotnetCliBundl
     }
 
     public async Task<ExecutionInfo> BuildAsync(string csProjFile, CancellationToken token) =>
-        await this.RunAsync(["build", csProjFile, "-v:q", "/nologo", "/nodereuse:false"], wait: true,
+        await this.RunAsync(["build", csProjFile, "-v:q", "/nologo", "/nodereuse:false"], foreground: true,
             token: token);
 }

--- a/src/Queil.Ring.DotNet.Cli/Tools/GitClone.cs
+++ b/src/Queil.Ring.DotNet.Cli/Tools/GitClone.cs
@@ -20,7 +20,7 @@ public partial class GitClone(ILogger<GitClone> logger, IOptions<RingConfigurati
         ringCfg?.Value ?? throw new NullReferenceException(nameof(ringCfg.Value));
 
     public string Command { get; set; } = "git";
-    public string[] DefaultArgs { get; set; } = Array.Empty<string>();
+    public string[] DefaultArgs { get; set; } = [];
     public ILogger<ITool> Logger { get; } = logger;
 
     public string ResolveFullClonePath(IFromGit gitCfg, string? rootPathOverride = null)

--- a/src/Queil.Ring.DotNet.Cli/Tools/GitClone.cs
+++ b/src/Queil.Ring.DotNet.Cli/Tools/GitClone.cs
@@ -45,7 +45,7 @@ public partial class GitClone(ILogger<GitClone> logger, IOptions<RingConfigurati
     private Func<CancellationToken, Task<ExecutionInfo>> Git(params string[] args)
     {
         return token => this.TryAsync(3, TimeSpan.FromSeconds(10),
-            t => t.RunAsync(args, wait: true, token: token), token);
+            t => t.RunAsync(args, foreground: true, token: token), token);
     }
 
     public async Task<ExecutionInfo> CloneOrPullAsync(IFromGit gitCfg, CancellationToken token, bool shallow = false,
@@ -66,7 +66,7 @@ public partial class GitClone(ILogger<GitClone> logger, IOptions<RingConfigurati
 
             if (shallow)
             {
-                var remoteBranchName = BranchRegex().Match(output.Output);
+                var remoteBranchName = BranchRegex().Match(output.Output.Split(Environment.NewLine)[0]);
                 if (!remoteBranchName.Success)
                     throw new InvalidOperationException(
                         $"Could not get branch name from git status output: {output.Output}");

--- a/src/Queil.Ring.DotNet.Cli/Tools/Kubectl.cs
+++ b/src/Queil.Ring.DotNet.Cli/Tools/Kubectl.cs
@@ -17,10 +17,10 @@ public class KubectlBundle(
     IOptions<RingConfiguration> config)
     : ITool
 {
-    private readonly string[] _allowedContexts = config.Value.Kubernetes.AllowedContexts ?? Array.Empty<string>();
+    private readonly string[] _allowedContexts = config.Value.Kubernetes.AllowedContexts ?? [];
 
     public string Command { get; set; } = "kubectl";
-    public string[] DefaultArgs { get; set; } = Array.Empty<string>();
+    public string[] DefaultArgs { get; set; } = [];
     public ILogger<ITool> Logger { get; } = logger;
 
     public async Task EnsureContextIsAllowed(CancellationToken token)

--- a/src/Queil.Ring.DotNet.Cli/Tools/Kubectl.cs
+++ b/src/Queil.Ring.DotNet.Cli/Tools/Kubectl.cs
@@ -25,7 +25,7 @@ public class KubectlBundle(
 
     public async Task EnsureContextIsAllowed(CancellationToken token)
     {
-        var result = await this.RunAsync(["config", "current-context"], wait: true, token: token);
+        var result = await this.RunAsync(["config", "current-context"], foreground: true, token: token);
         var currentContext = result.Output;
         if (!_allowedContexts.Contains(currentContext))
             throw new InvalidOperationException(
@@ -35,8 +35,12 @@ public class KubectlBundle(
     public async Task<bool> IsValidManifestAsync(string filePath, CancellationToken token)
     {
         var result = await this.RunAsync([
-            "apply", "--validate=true", "--dry-run=client", "-f", $"\"{filePath}\""
-        ], wait: true, token: token);
+            "apply",
+            "--validate=true",
+            "--dry-run=client",
+            "-f",
+            $"\"{filePath}\""
+        ], foreground: true, token: token);
         return result.IsSuccess;
     }
 
@@ -48,7 +52,7 @@ public class KubectlBundle(
     {
         await EnsureContextIsAllowed(token);
         return await this.RunAsync(["apply", "-o", $"jsonpath=\"{jsonPath}\"", "-f", $"\"{path}\""],
-            wait: true, token: token);
+            foreground: true, token: token);
     }
 
     public async Task<string[]> GetPods(string nameSpace)
@@ -68,7 +72,12 @@ public class KubectlBundle(
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(60));
         await EnsureContextIsAllowed(cts.Token);
         return await this.RunAsync([
-            "delete", "--ignore-not-found", "--wait=false", "--now=true", "-f", $"\"{path}\""
-        ], wait: true, token: cts.Token);
+            "delete",
+            "--ignore-not-found",
+            "--wait=false",
+            "--now=true",
+            "-f",
+            $"\"{path}\""
+        ], foreground: true, token: cts.Token);
     }
 }

--- a/src/Queil.Ring.DotNet.Cli/Tools/KustomizeTool.cs
+++ b/src/Queil.Ring.DotNet.Cli/Tools/KustomizeTool.cs
@@ -1,6 +1,5 @@
 namespace Queil.Ring.DotNet.Cli.Tools;
 
-using System;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
@@ -10,7 +9,7 @@ using Microsoft.Extensions.Logging;
 public class KustomizeTool(ILogger<ITool> logger) : ITool
 {
     public string Command { get; set; } = "kustomize";
-    public string[] DefaultArgs { get; set; } = Array.Empty<string>();
+    public string[] DefaultArgs { get; set; } = [];
     public ILogger<ITool> Logger { get; } = logger;
 
     public async Task<ExecutionInfo> BuildAsync(string kustomizeDir, string outputFilePath, CancellationToken token)

--- a/src/Queil.Ring.DotNet.Cli/Tools/KustomizeTool.cs
+++ b/src/Queil.Ring.DotNet.Cli/Tools/KustomizeTool.cs
@@ -15,7 +15,7 @@ public class KustomizeTool(ILogger<ITool> logger) : ITool
 
     public async Task<ExecutionInfo> BuildAsync(string kustomizeDir, string outputFilePath, CancellationToken token)
     {
-        var output = await this.RunAsync(["build", kustomizeDir], wait: true, token: token);
+        var output = await this.RunAsync(["build", kustomizeDir], foreground: true, token: token);
         await File.WriteAllTextAsync(outputFilePath, output.Output, token);
         return output;
     }

--- a/src/Queil.Ring.DotNet.Cli/Tools/ProcessRunner.cs
+++ b/src/Queil.Ring.DotNet.Cli/Tools/ProcessRunner.cs
@@ -1,12 +1,11 @@
 namespace Queil.Ring.DotNet.Cli.Tools;
 
-using System;
 using Abstractions.Tools;
 using Microsoft.Extensions.Logging;
 
 public class ProcessRunner(ILogger<ITool> logger) : ITool
 {
     public string Command { get; set; }
-    public string[] DefaultArgs { get; set; } = Array.Empty<string>();
+    public string[] DefaultArgs { get; set; } = [];
     public ILogger<ITool> Logger { get; } = logger;
 }

--- a/src/Queil.Ring.DotNet.Cli/Tools/RunProcess.cs
+++ b/src/Queil.Ring.DotNet.Cli/Tools/RunProcess.cs
@@ -14,7 +14,7 @@ using Abstractions.Tools;
 using Logging;
 using Microsoft.Extensions.Logging;
 
-public static class ToolExtensions
+public static class RunProcess
 {
     //TODO: this should be configurable
     private static readonly string[] FailureWords = ["err", "error", "fail"];
@@ -62,7 +62,7 @@ public static class ToolExtensions
         var procUid = Guid.NewGuid().ToString("n").Remove(10);
         try
         {
-            var allArgs = string.Join(" ", tool.DefaultArgs.Concat(args ?? Array.Empty<string>()));
+            var allArgs = string.Join(" ", tool.DefaultArgs.Concat(args ?? []));
             var sb = new StringBuilder();
 
             var s = new ProcessStartInfo

--- a/src/Queil.Ring.DotNet.Cli/Tools/ToolExtensions.cs
+++ b/src/Queil.Ring.DotNet.Cli/Tools/ToolExtensions.cs
@@ -96,11 +96,6 @@ public static class ToolExtensions
             p.ErrorDataReceived += OnError;
             p.Exited += OnExit;
 
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-            {
-                p.TrackAsChild();
-            }
-
             token.Register(() =>
             {
                 if (!tcs.TrySetCanceled()) return;
@@ -115,6 +110,12 @@ public static class ToolExtensions
             });
 
             p.Start();
+
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                p.TrackAsChild();
+            }
+
             if (!foreground) p.BeginOutputReadLine();
             p.BeginErrorReadLine();
 
@@ -126,8 +127,6 @@ public static class ToolExtensions
             {
                 await p.WaitForExitAsync(token);
                 result = new ExecutionInfo(p.Id, p.ExitCode, (await p.StandardOutput.ReadToEndAsync(token)).Trim('\r', '\n', ' ', '\t'), tcs.Task);
-
-                //result = await tcs.Task;
             }
             else
                 result = new ExecutionInfo(p.Id, null, sb.ToString().Trim('\r', '\n', ' ', '\t'), tcs.Task);

--- a/src/Queil.Ring.DotNet.Cli/Tools/ToolExtensions.cs
+++ b/src/Queil.Ring.DotNet.Cli/Tools/ToolExtensions.cs
@@ -55,7 +55,7 @@ public static class ToolExtensions
         string? workingDirectory = null,
         IDictionary<string, string>? envVars = null,
         Action<string>? onErrorData = null,
-        bool wait = false,
+        bool foreground = false,
         bool captureStdOut = true,
         CancellationToken token = default)
     {
@@ -86,29 +86,20 @@ public static class ToolExtensions
             tool.Logger.LogDebug("{procUid} - Starting process: {Tool} {Args} ({ProcessWorkingDir})", procUid,
                 tool.Command, allArgs, workingDirectory ?? ringWorkingDir);
 
-            var p = Process.Start(s);
-
-            if (p == null)
+            var tcs = new TaskCompletionSource<ExecutionInfo>();
+            var p = new Process
             {
-                tool.Logger.LogError("{procUid} - Process failed: {Tool} {Args} ({ProcessWorkingDir})", procUid,
-                    tool.Command, allArgs, workingDirectory ?? ringWorkingDir);
-                return new ExecutionInfo();
-            }
+                StartInfo = s,
+                EnableRaisingEvents = true
+            };
+            if (!foreground) p.OutputDataReceived += OnData;
+            p.ErrorDataReceived += OnError;
+            p.Exited += OnExit;
 
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
                 p.TrackAsChild();
             }
-
-            p.EnableRaisingEvents = true;
-            p.OutputDataReceived += OnData;
-            p.ErrorDataReceived += OnError;
-            p.BeginOutputReadLine();
-            p.BeginErrorReadLine();
-
-            tool.Logger.LogDebug("{procUid} - Process started: {Pid}", procUid, p.Id);
-
-            var tcs = new TaskCompletionSource<ExecutionInfo>();
 
             token.Register(() =>
             {
@@ -123,12 +114,21 @@ public static class ToolExtensions
                 }
             });
 
-            p.Exited += OnExit;
+            p.Start();
+            if (!foreground) p.BeginOutputReadLine();
+            p.BeginErrorReadLine();
+
+            tool.Logger.LogDebug("{procUid} - Process started: {Pid}", procUid, p.Id);
 
             ExecutionInfo result;
 
-            if (wait)
-                result = await tcs.Task;
+            if (foreground)
+            {
+                await p.WaitForExitAsync(token);
+                result = new ExecutionInfo(p.Id, p.ExitCode, (await p.StandardOutput.ReadToEndAsync(token)).Trim('\r', '\n', ' ', '\t'), tcs.Task);
+
+                //result = await tcs.Task;
+            }
             else
                 result = new ExecutionInfo(p.Id, null, sb.ToString().Trim('\r', '\n', ' ', '\t'), tcs.Task);
 
@@ -159,7 +159,6 @@ public static class ToolExtensions
                 e.Exited -= OnExit;
                 tcs.TrySetResult(new ExecutionInfo(e.Id, e.ExitCode, sb.ToString().Trim('\r', '\n', ' ', '\t'),
                     tcs.Task));
-                e.Dispose();
             }
 
             void OnError(object _, DataReceivedEventArgs x)

--- a/src/Queil.Ring.DotNet.Cli/Tools/Windows/ChildProcessTracker.cs
+++ b/src/Queil.Ring.DotNet.Cli/Tools/Windows/ChildProcessTracker.cs
@@ -49,7 +49,7 @@ internal static class ChildProcessTracker
         //  close the job handle, and when that happens, we want the child processes to
         //  be killed, too.
         var info = new JOBOBJECT_BASIC_LIMIT_INFORMATION
-            { LimitFlags = JOBOBJECTLIMIT.JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE };
+        { LimitFlags = JOBOBJECTLIMIT.JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE };
 
         var extendedInfo = new JOBOBJECT_EXTENDED_LIMIT_INFORMATION { BasicLimitInformation = info };
 

--- a/src/Queil.Ring.DotNet.Cli/Tools/Windows/IISExpressExe.cs
+++ b/src/Queil.Ring.DotNet.Cli/Tools/Windows/IISExpressExe.cs
@@ -1,6 +1,5 @@
 namespace Queil.Ring.DotNet.Cli.Tools.Windows;
 
-using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
@@ -10,7 +9,7 @@ using Microsoft.Extensions.Logging;
 public class IISExpressExe(ILogger<IISExpressExe> logger) : ITool
 {
     public string Command { get; set; } = @"C:\Program Files\IIS Express\iisexpress.exe";
-    public string[] DefaultArgs { get; set; } = Array.Empty<string>();
+    public string[] DefaultArgs { get; set; } = [];
     public ILogger<ITool> Logger { get; } = logger;
 
     private void OnError(string error)

--- a/src/Queil.Ring.DotNet.Cli/Workspace/RunnableContainer.cs
+++ b/src/Queil.Ring.DotNet.Cli/Workspace/RunnableContainer.cs
@@ -46,6 +46,8 @@ internal sealed class RunnableContainer : IAsyncDisposable
         return container;
     }
 
+    public Task ConfigureAsync() => Runnable.ConfigureAsync(_aggregateCts.Token);
+
     public void Start()
     {
         Task = Runnable.RunAsync(_aggregateCts.Token);

--- a/src/Queil.Ring.DotNet.Cli/Workspace/WorkspaceInitHook.cs
+++ b/src/Queil.Ring.DotNet.Cli/Workspace/WorkspaceInitHook.cs
@@ -29,7 +29,7 @@ public class WorkspaceInitHook : IWorkspaceInitHook
         if (_configured)
         {
             _logger.LogDebug("Executing Workspace Init Hook");
-            await _runner.RunAsync(wait: true, token: token);
+            await _runner.RunAsync(foreground: true, token: token);
         }
         else
         {

--- a/src/Queil.Ring.DotNet.Cli/Workspace/WorkspaceLauncher.cs
+++ b/src/Queil.Ring.DotNet.Cli/Workspace/WorkspaceLauncher.cs
@@ -298,7 +298,7 @@ public sealed class WorkspaceLauncher : IWorkspaceLauncher, IDisposable
     private void PublishStatusCore(ServerState serverState, bool force)
     {
         var state = serverState == ServerState.IDLE ? WorkspaceState.NONE :
-            !_runnables.Any() ? WorkspaceState.IDLE :
+            _runnables.IsEmpty ? WorkspaceState.IDLE :
             _runnables.Values.Select(x => x.Runnable)
                 .All(r => r.State == State.ProbingHealth || r.State == State.Healthy) ? WorkspaceState.HEALTHY :
             WorkspaceState.DEGRADED;

--- a/src/Queil.Ring.DotNet.Cli/Workspace/WorkspaceLauncher.cs
+++ b/src/Queil.Ring.DotNet.Cli/Workspace/WorkspaceLauncher.cs
@@ -256,6 +256,7 @@ public sealed class WorkspaceLauncher : IWorkspaceLauncher, IDisposable
 
         _runnables.TryAdd(id, container);
 
+        await container.ConfigureAsync();
         if (start) container.Start();
     }
 
@@ -266,7 +267,19 @@ public sealed class WorkspaceLauncher : IWorkspaceLauncher, IDisposable
         Interlocked.Decrement(ref _initCounter);
         container.Runnable.OnHealthCheckCompleted -= OnPublishStatus;
         container.Runnable.OnInitExecuted -= OnRunnableInitExecuted;
-        await container.DisposeAsync();
+        try
+        {
+            await container.DisposeAsync();
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug(ex, "Runnable disposal failed");
+            return false;
+        }
         return true;
     }
 

--- a/tests/resources/basic/netcore.toml
+++ b/tests/resources/basic/netcore.toml
@@ -2,3 +2,8 @@
 sshRepoUrl = "git@github.com:queil/k8s-debug-poc.git"
 csproj = "src/k8s-debug-poc.fsproj"
 tags = ["poc"]
+
+[aspnetcore.tasks.build]
+  bringDown = true
+  command = "dotnet"
+  args = ["build"]


### PR DESCRIPTION
This PR contains:
- [x] - fix: behaviour when a task fails (if runnable was brought down it should be brought up in initiated state (aka cold))
- [x] - fix: race condition when attaching events to process
- [x] - fix: read stdout synchronously if running process in foreground
- [x] - fix: git failing to pull from repository when it has local modifications
- [x] - chore: use modern syntax (`[]`) for empty array initialization
